### PR TITLE
Fix parent modal run

### DIFF
--- a/src/ModalAjax.php
+++ b/src/ModalAjax.php
@@ -183,7 +183,7 @@ class ModalAjax extends Widget
      */
     public function run()
     {
-        $this->_modal->run();
+        echo $this->_modal->run();
 
         /** @var View */
         $view = $this->getView();


### PR DESCRIPTION
after (https://github.com/yiisoft/yii2-bootstrap5/commit/3197d692650f789865e31db73126a17fa31daedd) parent not echoing its content anymore. Now it returns content. Echoing it by ourselves